### PR TITLE
chore(android): bump AGP to 9.2.1 + Gradle to 9.5.1 (CI alignment)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Build
+
+- Bumped Android Gradle Plugin `8.13.0` → `9.2.1` and Gradle wrapper `8.14.3` → `9.5.1` so the plugin's own CI builds against the same AGP major (9.x) that consumer apps use. No consumer-facing change — consuming apps apply their own root AGP at build time.
+
 ## 2.0.1 (2026-05-21)
 
 ### Bug Fixes

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.0'
+        classpath 'com.android.tools.build:gradle:9.2.1'
     }
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

Bumps the plugin's own build toolchain to match the AGP major used by consumer apps:

- `android/build.gradle`: `com.android.tools.build:gradle` `8.13.0` → `9.2.1`
- `android/gradle/wrapper/gradle-wrapper.properties`: Gradle `8.14.3` → `9.5.1` (AGP 9.2 requires Gradle ≥ 9.4.1)

## Why

The buildscript AGP version declared by a Capacitor plugin is **not** applied by consuming apps (they use their own root AGP, e.g. 9.2.1). So the plugin's CI was building against an older AGP major than production. This is exactly what let the keep-awake `proguard-android.txt` issue pass CI. Aligning the toolchain makes CI catch AGP-9 incompatibilities.

## Scope

CI / maintenance only — **no consumer-facing change**. Ships as an `Unreleased` CHANGELOG entry; **no version bump and no npm release** (consumers gain nothing from this).

## Validation

Relies on this PR's CI (web + android + ios) building green under AGP 9.2.1 / Gradle 9.5.1. No local Android SDK available.