### PR TITLE
feat: eventos kioskEntered / kioskExited (v2.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,34 @@ toggleKioskMode() => Promise<void>
 
 Toggles kiosk mode based on the current state.
 
+---
+
+### addListener('kioskEntered', ...)
+
+```typescript
+addListener(
+  eventName: 'kioskEntered',
+  listenerFunc: (event: { timestamp: number }) => void,
+) => Promise<PluginListenerHandle>
+```
+
+Fires when the app enters kiosk (lock task) mode. `timestamp` is the epoch time in milliseconds.
+
+---
+
+### addListener('kioskExited', ...)
+
+```typescript
+addListener(
+  eventName: 'kioskExited',
+  listenerFunc: (event: { reason: 'user' | 'system' | 'api'; timestamp: number }) => void,
+) => Promise<PluginListenerHandle>
+```
+
+Fires when the app leaves kiosk mode. `reason` is `'api'` when triggered by `exitKioskMode()`, or `'user'` when the exit is detected on the next foreground.
+
+Android does not push lock-task changes to normal apps, so a user/system exit performed while the app is backgrounded is only detected when the activity next resumes (latency). Real-time detection requires the app to be Device Owner; `'system'` is reserved for that future detector.
+
 ## Migration from v1
 
 v2 is a breaking change due to the Capacitor 5 → 8 upgrade:

--- a/android/src/main/java/com/gachlab/capacitor/kiosk/KioskModePlugin.java
+++ b/android/src/main/java/com/gachlab/capacitor/kiosk/KioskModePlugin.java
@@ -11,6 +11,52 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 @CapacitorPlugin(name = "KioskMode")
 public class KioskModePlugin extends Plugin {
 
+    private boolean lastKioskState;
+
+    @Override
+    public void load() {
+        try {
+            lastKioskState = checkKioskState();
+        } catch (Exception e) {
+            lastKioskState = false;
+        }
+    }
+
+    /**
+     * Android does not broadcast lock-task changes to normal apps, so an exit
+     * performed by the user (or a re-entry) is detected when the activity next
+     * comes to the foreground.
+     */
+    @Override
+    protected void handleOnResume() {
+        try {
+            boolean current = checkKioskState();
+            if (current != lastKioskState) {
+                if (current) {
+                    emitKioskEntered();
+                } else {
+                    emitKioskExited("user");
+                }
+                lastKioskState = current;
+            }
+        } catch (Exception e) {
+            // Activity not available; nothing to report.
+        }
+    }
+
+    private void emitKioskEntered() {
+        JSObject data = new JSObject();
+        data.put("timestamp", System.currentTimeMillis());
+        notifyListeners("kioskEntered", data);
+    }
+
+    private void emitKioskExited(String reason) {
+        JSObject data = new JSObject();
+        data.put("reason", reason);
+        data.put("timestamp", System.currentTimeMillis());
+        notifyListeners("kioskExited", data);
+    }
+
     private boolean checkKioskState() {
         ActivityManager am = (ActivityManager) getActivity().getApplicationContext().getSystemService(Context.ACTIVITY_SERVICE);
         return am.getLockTaskModeState() > ActivityManager.LOCK_TASK_MODE_NONE;
@@ -31,6 +77,8 @@ public class KioskModePlugin extends Plugin {
     public void enterKioskMode(PluginCall call) {
         try {
             getActivity().startLockTask();
+            lastKioskState = true;
+            emitKioskEntered();
             call.resolve();
         } catch (SecurityException e) {
             call.reject("Cannot enter kiosk mode: app must be device owner or activity must be whitelisted", e);
@@ -43,6 +91,8 @@ public class KioskModePlugin extends Plugin {
     public void exitKioskMode(PluginCall call) {
         try {
             getActivity().stopLockTask();
+            lastKioskState = false;
+            emitKioskExited("api");
             call.resolve();
         } catch (SecurityException e) {
             call.reject("Cannot exit kiosk mode: app must be device owner", e);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gachlab/capacitor-kiosk",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gachlab/capacitor-kiosk",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gachlab/capacitor-kiosk",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Capacitor plugin for Android kiosk mode (Lock Task). Pin your app to the screen and prevent users from leaving.",
   "type": "module",
   "main": "dist/plugin.cjs.js",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,3 +1,5 @@
+import type { PluginListenerHandle } from '@capacitor/core';
+
 export interface KioskModePlugin {
   /**
    * Returns whether the device is currently in kiosk (lock task) mode.
@@ -19,4 +21,32 @@ export interface KioskModePlugin {
    * Toggles kiosk mode on or off based on the current state.
    */
   toggleKioskMode(): Promise<void>;
+
+  /**
+   * Emitted when the app enters kiosk (lock task) mode. `timestamp` is the
+   * epoch time in milliseconds when it was observed.
+   */
+  addListener(
+    eventName: 'kioskEntered',
+    listenerFunc: (event: { timestamp: number }) => void,
+  ): Promise<PluginListenerHandle>;
+
+  /**
+   * Emitted when the app leaves kiosk mode.
+   *
+   * `reason` is `'api'` when triggered by `exitKioskMode()`, or `'user'` when an
+   * exit is detected on the next foreground (Android does not push lock-task
+   * changes to normal apps, so user/system exits are detected on resume —
+   * `'system'` is reserved for a future Device Owner break detector).
+   * `timestamp` is the epoch time in milliseconds when it was observed.
+   */
+  addListener(
+    eventName: 'kioskExited',
+    listenerFunc: (event: { reason: 'user' | 'system' | 'api'; timestamp: number }) => void,
+  ): Promise<PluginListenerHandle>;
+
+  /**
+   * Removes all listeners for this plugin.
+   */
+  removeAllListeners(): Promise<void>;
 }


### PR DESCRIPTION
## Fase 1 del ROADMAP

Añade eventos de estado para no tener que hacer polling de `isInKioskMode()`:
- `kioskEntered { timestamp }`
- `kioskExited { reason: 'user' | 'system' | 'api'; timestamp }`

### Detección
- Enter/exit vía API emiten directo (`reason: 'api'`).
- Android no emite broadcast de Lock Task para apps normales → una salida del usuario se detecta en el siguiente foreground (`handleOnResume` compara `getLockTaskModeState()` con el último estado, `reason: 'user'`).
- **Limitación:** salida en background se detecta al re-entrar (latencia); detección firme/real-time requiere Device Owner (`'system'` reservado). Android-only.

### Release
Sale como **2.1.0**, arrastrando el bump **AGP 9.2.1 / Gradle 9.5.1** ya mergeado sin release npm.

Closes #3